### PR TITLE
Implementation of BT.redeem interaction layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ You can use brandedtoken.js to interact with BrandedToken contracts.
 
 ### Notable Changes
 
+* Implementation of BrandedToken.redeem interaction layer (#[134](https://github.com/OpenST/brandedtoken.js/pull/134))
+* Merge release-0.10 into develop (#[133](https://github.com/OpenST/brandedtoken.js/pull/133))
+* Updated openstfoundation to openst (#[130](https://github.com/OpenST/brandedtoken.js/pull/130))
+* Rename registerInternalActor to registerInternalActors (#[128](https://github.com/OpenST/brandedtoken.js/pull/128))
+* Release of version 0.10.0-alpha.2 (#[124](https://github.com/OpenST/brandedtoken.js/pull/124))
+* Changelog and readme update (#[123](https://github.com/OpenST/brandedtoken.js/pull/123))
+* Deprecation of StakeHelper and EconomySetup (#[121](https://github.com/OpenST/brandedtoken.js/pull/121))
+* Remove license from top of javascript files (#[118](https://github.com/OpenST/brandedtoken.js/pull/118))
 * ABIs and BINs are now accessed as a dependency on brandedtoken-contracts ([#117](https://github.com/OpenST/brandedtoken.js/pull/117))
 * Mosaic.js version is upgraded to beta-4 (#[115](https://github.com/OpenST/brandedtoken.js/pull/115))
 * Mosaic contract interacts are now exposed ([#114](https://github.com/OpenST/brandedtoken.js/pull/114))

--- a/lib/ContractInteract/BrandedToken.js
+++ b/lib/ContractInteract/BrandedToken.js
@@ -48,6 +48,9 @@ class BrandedToken {
     this.isUnrestricted = this.isUnrestricted.bind(this);
     this.rejectStakeRequest = this.rejectStakeRequest.bind(this);
     this.rejectStakeRequestRawTx = this.rejectStakeRequestRawTx.bind(this);
+    this.redeem = this.redeem.bind(this);
+    this.redeemRawTx = this.redeemRawTx.bind(this);
+    this.convertToValueTokens = this.convertToValueTokens.bind(this);
   }
 
   /**
@@ -374,6 +377,7 @@ class BrandedToken {
    *
    * @param {string} stakeRequestHash Hash of stake request information
    *                                  calculated per EIP 712.
+   * @param {Object} txOptions Transaction options.
    *
    * @return {Promise<Object>} Promise that resolves to transaction receipt.
    */
@@ -410,6 +414,61 @@ class BrandedToken {
     return Promise.resolve(
       this.contract.methods.rejectStakeRequest(stakeRequestHash),
     );
+  }
+
+  /**
+   * This reedems brandedToken, must be called by beneficiary.
+   *
+   * @param {string} btToRedeem Amount of brandedTokens to redeem.
+   * @param {Object} txOptions Transaction options.
+   *
+   * @return {Promise<Object>} Promise that resolves to transaction receipt.
+   */
+  async redeem(btToRedeem, txOptions) {
+    if (!txOptions) {
+      const err = new TypeError(`Invalid transaction options: ${txOptions}.`);
+      return Promise.reject(err);
+    }
+    if (!Web3.utils.isAddress(txOptions.from)) {
+      const err = new TypeError(
+        `Invalid from address ${txOptions.from} in transaction options.`,
+      );
+      return Promise.reject(err);
+    }
+
+    const txObject = await this.redeemRawTx(btToRedeem);
+    return Utils.sendTransaction(txObject, txOptions);
+  }
+
+  /**
+   * This returns raw tx for amount to redeem.
+   *
+   * @param {string} btToRedeem Amount of brandedTokens to redeem.
+   *
+   * @return Promise<Object> Raw transaction object.
+   */
+  redeemRawTx(btToRedeem) {
+    if (!btToRedeem) {
+      const err = new TypeError(`Invalid redeemAmount: ${btToRedeem}.`);
+      return Promise.reject(err);
+    }
+
+    return Promise.resolve(
+      this.contract.methods.redeem(btToRedeem),
+    );
+  }
+
+  /**
+   * This calculates values tokens equivalent to given branded tokens.
+   *
+   * @param {string} brandedTokens Amount of branded tokens.
+   *
+   * @return {Promise<string>} Promise that resolves to amount of value tokens.
+   */
+  convertToValueTokens(brandedTokens) {
+    return this.contract.methods
+      .convertToValueTokens(brandedTokens)
+      .call();
   }
 }
 

--- a/lib/ContractInteract/BrandedToken.js
+++ b/lib/ContractInteract/BrandedToken.js
@@ -417,14 +417,16 @@ class BrandedToken {
   }
 
   /**
-   * This reedems brandedToken, must be called by beneficiary.
+   * Redeems an amount of BrandedToken and returns the equivalent amount staked value tokens
+   * to the same address.
    *
-   * @param {string} btToRedeem Amount of brandedTokens to redeem.
+   * @param {string} amount Amount of brandedTokens to redeem.
+   *                        Amount unit is wei i.e.1 BT = 10^18 wei.
    * @param {Object} txOptions Transaction options.
    *
    * @return {Promise<Object>} Promise that resolves to transaction receipt.
    */
-  async redeem(btToRedeem, txOptions) {
+  async redeem(amount, txOptions) {
     if (!txOptions) {
       const err = new TypeError(`Invalid transaction options: ${txOptions}.`);
       return Promise.reject(err);
@@ -436,25 +438,26 @@ class BrandedToken {
       return Promise.reject(err);
     }
 
-    const txObject = await this.redeemRawTx(btToRedeem);
+    const txObject = await this.redeemRawTx(amount);
     return Utils.sendTransaction(txObject, txOptions);
   }
 
   /**
-   * This returns raw tx for amount to redeem.
+   * This method returns redeem raw tx object.
    *
-   * @param {string} btToRedeem Amount of brandedTokens to redeem.
+   * @param {string} amount Amount of brandedTokens to redeem.
+   *                        Amount unit is wei i.e.1 BT = 10^18 wei.
    *
    * @return Promise<Object> Raw transaction object.
    */
-  redeemRawTx(btToRedeem) {
-    if (!btToRedeem) {
-      const err = new TypeError(`Invalid redeemAmount: ${btToRedeem}.`);
+  redeemRawTx(amount) {
+    if (!amount) {
+      const err = new TypeError(`Invalid redeemAmount: ${amount}.`);
       return Promise.reject(err);
     }
 
     return Promise.resolve(
-      this.contract.methods.redeem(btToRedeem),
+      this.contract.methods.redeem(amount),
     );
   }
 

--- a/test/unit/BrandedToken/convertToValueTokens.js
+++ b/test/unit/BrandedToken/convertToValueTokens.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const Web3 = require('web3');
+const sinon = require('sinon');
+const { assert } = require('chai');
+
+const Spy = require('../../utils/Spy');
+const BrandedToken = require('../../../lib/ContractInteract/BrandedToken');
+
+describe('BrandedToken.convertToValueTokens()', () => {
+  let brandedToken;
+
+  beforeEach(() => {
+    const web3 = new Web3();
+    const tokenAddress = '0x0000000000000000000000000000000000000002';
+    brandedToken = new BrandedToken(web3, tokenAddress);
+  });
+
+  it('should return expected value', async () => {
+    const brandedTokens = '100';
+
+    const convertToValueTokensSpy = sinon.replace(
+      brandedToken.contract.methods,
+      'convertToValueTokens',
+      sinon.fake.returns({
+        call: () => Promise.resolve(true),
+      }),
+    );
+    const response = await brandedToken.convertToValueTokens(brandedTokens);
+
+    assert.isTrue(
+      response,
+      'convertToValueTokens must return true',
+    );
+
+    Spy.assert(convertToValueTokensSpy, 1, [[brandedTokens]]);
+    sinon.restore();
+  });
+});

--- a/test/unit/BrandedToken/redeem.js
+++ b/test/unit/BrandedToken/redeem.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const Web3 = require('web3');
+const sinon = require('sinon');
+const { assert } = require('chai');
+
+const Spy = require('../../utils/Spy');
+const AssertAsync = require('../../utils/AssertAsync');
+const BrandedToken = require('../../../lib/ContractInteract/BrandedToken');
+const Utils = require('../../../utils/Utils');
+
+describe('BrandedToken.redeem()', () => {
+  let brandedToken;
+  let web3;
+
+  beforeEach(() => {
+    web3 = new Web3();
+    const tokenAddress = '0x0000000000000000000000000000000000000002';
+    brandedToken = new BrandedToken(web3, tokenAddress);
+  });
+
+  it('should pass with correct params', async () => {
+    const brandedTokens = '100';
+    const mockRawTx = 'mockRawTx';
+
+    const rawTx = sinon.replace(
+      brandedToken,
+      'redeemRawTx',
+      sinon.fake.resolves(mockRawTx),
+    );
+
+    const spySendTransaction = sinon.replace(
+      Utils,
+      'sendTransaction',
+      sinon.fake.resolves(true),
+    );
+    const txOptions = {
+      from: '0x0000000000000000000000000000000000000003',
+    };
+    const response = await brandedToken.redeem(
+      brandedTokens,
+      txOptions,
+    );
+    assert.isTrue(
+      response,
+      'Redeem should return true',
+    );
+    Spy.assert(rawTx, 1, [[brandedTokens]]);
+    Spy.assert(spySendTransaction, 1, [[mockRawTx, txOptions]]);
+    sinon.restore();
+  });
+
+  it('should throw an error when transaction options is undefined', async () => {
+    const brandedTokens = '100';
+    const txOptions = undefined;
+
+    await AssertAsync.reject(
+      brandedToken.redeem(brandedTokens, txOptions),
+      'Invalid transaction options: undefined.',
+    );
+  });
+
+  it('should throw an error when from address is undefined', async () => {
+    const brandedTokens = '100';
+    const txOptions = {};
+    await AssertAsync.reject(
+      brandedToken.redeem(brandedTokens, txOptions),
+      `Invalid from address ${txOptions.from} in transaction options.`,
+    );
+  });
+});

--- a/test/unit/BrandedToken/redeemRawTx.js
+++ b/test/unit/BrandedToken/redeemRawTx.js
@@ -43,7 +43,7 @@ describe('BrandedToken.redeemRawTx()', () => {
     sinon.restore();
   });
 
-  it('should throw an error when brandedTokens is invalid', async () => {
+  it('should throw an error when brandedTokens are invalid', async () => {
     const brandedTokens = undefined;
     await AssertAsync.reject(
       brandedToken.redeemRawTx(brandedTokens),

--- a/test/unit/BrandedToken/redeemRawTx.js
+++ b/test/unit/BrandedToken/redeemRawTx.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const Web3 = require('web3');
+const sinon = require('sinon');
+const { assert } = require('chai');
+
+const Spy = require('../../utils/Spy');
+const BrandedToken = require('../../../lib/ContractInteract/BrandedToken');
+const AssertAsync = require('../../utils/AssertAsync');
+
+describe('BrandedToken.redeemRawTx()', () => {
+  let brandedToken;
+  let web3;
+
+  beforeEach(() => {
+    web3 = new Web3();
+    const tokenAddress = '0x0000000000000000000000000000000000000002';
+    brandedToken = new BrandedToken(web3, tokenAddress);
+  });
+
+  it('should return correct raw tx', async () => {
+    const mockTx = 'mockTx';
+
+    const spyRawTx = sinon.replace(
+      brandedToken.contract.methods,
+      'redeem',
+      sinon.fake.resolves(mockTx),
+    );
+
+    const brandedTokens = '100';
+
+    const response = await brandedToken.redeemRawTx(
+      brandedTokens,
+    );
+
+    assert.strictEqual(
+      response,
+      mockTx,
+      'It must return correct raw tx',
+    );
+
+    Spy.assert(spyRawTx, 1, [[brandedTokens]]);
+    sinon.restore();
+  });
+
+  it('should throw an error when brandedTokens is invalid', async () => {
+    const brandedTokens = undefined;
+    await AssertAsync.reject(
+      brandedToken.redeemRawTx(brandedTokens),
+      `Invalid redeemAmount: ${brandedTokens}.`,
+    );
+  });
+});


### PR DESCRIPTION
To convert BT to OST below method needs to be implemented in BrandedToken interaction layer:

- Implementation of BrandedToken redeem interaction layer method.
   Interface looks like below:
```
function redeem(
        brandedTokens,
        txOptions,
    )
```
- Implementation of convertToValueTokens so that callers can validate amount of valueToken that should be redeemed.

- Appropriate Unit tests are also added.

Fixes #126 